### PR TITLE
Check __ANDROID_API__ instead of defining it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -290,6 +290,7 @@ lazy_static = "1.0"
 # control about what should be parallised in which way
 cc = "1.0.3"
 rayon = "0.9.0"
+tempfile = "2.2.0"
 
 [features]
 # These features are documented in the top-level module's documentation.


### PR DESCRIPTION
This pull requests removes the code that automatically defines the __ANDROID_API__ constant, and replaces it by a code that checks whether the constant has been defined by something else.
In other words, we now assume that the user manually defines __ANDROID_API__, for example through the CFLAGS environment variable.

The main reason is practical. If you generate a standalone NDK toolchain in order to compile your project, the wrapper automatically passes the __ANDROID_API__ constant to the actual compiler. Therefore if you try to compile ring for the standalone toolchain, you will most likely get a compilation error because the constant passed by the standalone conflicts with the one defined by ring.
