### PR TITLE
Fix the build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -33,7 +33,6 @@
     unused_qualifications,
     unused_results,
     variant_size_differences,
-    warnings,
 )]
 
 extern crate cc;


### PR DESCRIPTION
Same effect as #2 but through a different mean.

In general I think that `#![deny(warnings)]` is a bad idea because it leads to exactly these kinds of problems.